### PR TITLE
Publish tweaks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": true
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebranly/react-awesome-query-builder",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-awesome-query-builder",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@sebranly/react-awesome-query-builder",
   "version": "4.0.1",
+  "files": [
+    "lib/**/*"
+  ],
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-awesome-query-builder",
+  "name": "@sebranly/react-awesome-query-builder",
   "version": "4.0.0",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
@@ -28,7 +28,7 @@
   "main": "lib",
   "types": "modules/index.d.ts",
   "scripts": {
-    "prepublish": "npm run build-npm",
+    "prepare": "npm run build-npm",
     "for-npm": "./scripts/for-npm.sh",
     "for-gpr": "./scripts/for-gpr.sh",
     "build-npm": "./scripts/build-npm.sh",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebranly/react-awesome-query-builder",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "files": [
     "lib/**/*"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebranly/react-awesome-query-builder",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "files": [
     "lib/**/*"
   ],

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lint-fix": "./node_modules/.bin/eslint --ext .jsx --ext .js --ext .tsx --fix ./modules/ ./sandbox/ ./sandbox_simple/ ./examples/ ./tests/",
     "lint": "./node_modules/.bin/eslint --ext .jsx --ext .js --ext .tsx ./modules/ ./sandbox/ ./sandbox_simple/ ./examples/ ./tests/"
   },
+  "private": false,
   "repository": {
     "type": "git",
     "url": "https://github.com/ukrbublik/react-awesome-query-builder.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebranly/react-awesome-query-builder",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "files": [
     "lib/**/*"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebranly/react-awesome-query-builder",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@sebranly/react-awesome-query-builder",
   "version": "4.0.4",
-  "files": [
-    "lib/**/*"
-  ],
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sebranly/react-awesome-query-builder",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "User-friendly query builder for React. Demo: https://ukrbublik.github.io/react-awesome-query-builder",
   "keywords": [
     "query-builder",
@@ -52,7 +52,9 @@
     "url": "https://github.com/ukrbublik/react-awesome-query-builder/issues"
   },
   "homepage": "https://github.com/ukrbublik/react-awesome-query-builder",
-  "funding": "https://opencollective.com/react-awesome-query-builder",
+  "funding": {
+    "url": "https://opencollective.com/react-awesome-query-builder"
+  },
   "engines": {
     "node": ">=10.14",
     "npm": ">=6"


### PR DESCRIPTION
This PR allows me to publish the package under my own space on NPM.

Note:
- `node -v` is `v14.15.0`
- `npm -v` is `7.6.3`

In `examples` sub-folder, there shouldn't be any `node_modules` folder as it didn't seem like the publish script would remove it/omit it.

- `npm version patch` (I ran `npm version major` at the beginning to reach 4 instead of 3 in case there would be overlap with original package [very unlikely thanks to NPM access restrictions])
- push commit to publish branch
- `npm publish`

https://www.npmjs.com/package/react-awesome-query-builder and https://www.npmjs.com/package/@sebranly/react-awesome-query-builder should be similar in sizes